### PR TITLE
fixing conflicting password rules

### DIFF
--- a/src/PasswordPurgatory/PasswordPurgatory.Web/Models/Check.cs
+++ b/src/PasswordPurgatory/PasswordPurgatory.Web/Models/Check.cs
@@ -194,12 +194,12 @@ public class Check
             InfuriationLevel = InfuriationLevel.Ridiculous,
             Validator = (un, pwd) => Regex.Match(pwd, @"/[ÄÜÖ\u1e9e]/").Success
         },
-        new()
+        /*new()
         {
             Message = "Password must contain only unique characters.",
             InfuriationLevel = InfuriationLevel.Ridiculous,
             Validator = (un, pwd) => !Regex.Match(pwd, @"/(?=^[A-Za-z0-9]+$)(.)+.*\1.*/").Success //regex matches when there's a duplicate character
-        },
+        },*/
         new()
         {
             Message = "Password must contain 'Password must contain' (case sensitive)",


### PR DESCRIPTION
commenting out requirement for a password to contain only unique characters

Addressing https://github.com/LanceMcCarthy/dotnet-password-purgatory/issues/7